### PR TITLE
tebex: do not disable tls verification (insecure)

### DIFF
--- a/Tebex-TorchAPI/Tebex.cs
+++ b/Tebex-TorchAPI/Tebex.cs
@@ -53,9 +53,6 @@ namespace TebexTorchAPI
             if (_sessionManager != null)
                 _sessionManager.SessionStateChanged += SessionChanged;
 
-            System.Net.ServicePointManager.ServerCertificateValidationCallback +=
-                            (sender, certificate, chain, errors) => { return true; };
-
             Torch.GameStateChanged += GameStateChanged;
 
             this.information = new WebstoreInfo();


### PR DESCRIPTION
Hello,

I suspect, as is usually the case, that this was a hack during development, ignore certificate check so you can send it to a dev instance of your API server, and it can now be removed.

It's worse than it looks: this not only disables it for your own http client to make API calls, it disables it for the whole binary, so you're making https calls by Space Engineers itself as well and other Torch plugins, now insecure and vulnerable to man-in-the-middle attacks. Knowing Torch itself as well as some plugins have auto-update features (e.g. download an updated dll and restart), this could result in arbitrary code execution and compromise of the server in the worst case.

Affected since: December 14th 2018 according to the commit history, so 3+ years.

Variant analysis: I have not looked at your other games plugin see if they're affected. If you share code between them, you might want to check that.

See also: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5359
If you still need to disable it for some reason, see the example from Microsoft on how to disable it just for specific URLs, instead of everything, and at least make it a setting, so the default is safe, but server owners or developers have the ability to disable tls verification if desired.

Cheers